### PR TITLE
Update unbalanced_modality.jl

### DIFF
--- a/src/unbalanced_modality.jl
+++ b/src/unbalanced_modality.jl
@@ -171,7 +171,7 @@ function unbalanced_modality(
     for iter = 1:iterations
 
         if reg_m > 0.0
-            G = PythonOT.entropic_partial_wasserstein(wa2, wb2, C, reg)
+            G = PythonOT.entropic_partial_wasserstein(wa2, wb2, C, reg) #Pourquoi il n'y a pas le paramètre m à calibrer ot.partial.entropic_partial_wasserstein(a, b, M, reg, m)
         else
             G = PythonOT.emd(wa2, wb2, C)
         end


### PR DESCRIPTION
j'ai ajouté un commentaire ot.partial.entropic_partial_wasserstein(a, b, M, reg, m=None)

il manque le paramètre m à calibrer

Je ne vois pas le calcul de la fonction G*cost