### PR TITLE
Update dependabot.yml to remove labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,3 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 99
-    labels:
-      - "dependencies"
-      - "github-actions"


### PR DESCRIPTION
Removed labels from GitHub Actions configuration.